### PR TITLE
BREAKING: Token standards ergonomics improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 ## NFT
 
-```diff
-use near_sdk::{near, PanicOnDefault};
-+ use near_sdk_contract_tools::nft::*;
+```rust
+use near_sdk::near;
+use near_sdk_contract_tools::nft::*;
 
-#[derive(PanicOnDefault)]
-+ #[derive(NonFungibleToken)]
+#[derive(Default, NonFungibleToken)]
 #[near(contract_state)]
 pub struct MyNftContract {}
 
@@ -17,11 +16,11 @@ impl MyNftContract {
     pub fn new() -> Self {
         let mut contract = Self {};
 
-+         contract.set_contract_metadata(ContractMetadata::new(
-+             "My NFT".to_string(),
-+             "MNFT".to_string(),
-+             None,
-+         ));
+        contract.set_contract_metadata(&ContractMetadata::new(
+            "My NFT".to_string(),
+            "MNFT".to_string(),
+            None,
+        ));
 
         contract
     }
@@ -30,12 +29,11 @@ impl MyNftContract {
 
 ## FT
 
-```diff
-use near_sdk::{near, PanicOnDefault};
-+ use near_sdk_contract_tools::ft::*;
+```rust
+use near_sdk::near;
+use near_sdk_contract_tools::ft::*;
 
-#[derive(PanicOnDefault)]
-+ #[derive(FungibleToken)]
+#[derive(Default, FungibleToken)]
 #[near(contract_state)]
 pub struct MyFtContract {}
 
@@ -45,11 +43,11 @@ impl MyFtContract {
     pub fn new() -> Self {
         let mut contract = Self {};
 
-+         contract.set_metadata(&FungibleTokenMetadata::new(
-+             "My Fungible Token".into(),
-+             "MYFT".into(),
-+             24,
-+         ));
+        contract.set_metadata(&ContractMetadata::new(
+            "My Fungible Token".into(),
+            "MYFT".into(),
+            24,
+        ));
 
         contract
     }
@@ -157,10 +155,10 @@ e.emit();
 To create a contract that is compatible with the [NEP-141][nep141], [NEP-145][nep145], and [NEP-148][nep148] standards, that emits standard-compliant ([NEP-297][nep297]) events.
 
 ```rust
+use near_sdk::near;
 use near_sdk_contract_tools::ft::*;
-use near_sdk::{near, PanicOnDefault};
 
-#[derive(FungibleToken, PanicOnDefault)]
+#[derive(Default, FungibleToken)]
 #[near(contract_state)]
 struct MyFt {}
 
@@ -170,7 +168,7 @@ impl MyFt {
     pub fn new() -> Self {
         let mut contract = Self {};
 
-        contract.set_metadata(&FungibleTokenMetadata::new(
+        contract.set_metadata(&ContractMetadata::new(
             "My Fungible Token".to_string(),
             "MYFT".to_string(),
             24,

--- a/macros/src/standard/event.rs
+++ b/macros/src/standard/event.rs
@@ -63,7 +63,7 @@ pub fn event_attribute(
     let me_str = quote! { #me }.to_string();
 
     Ok(quote::quote! {
-        #[derive(#macros::Nep297, #serde::Serialize)]
+        #[derive(#macros::Nep297, #serde::Serialize, #serde::Deserialize)]
         #[nep297(
             crate = #me_str,
             standard = #standard,

--- a/macros/src/standard/fungible_token.rs
+++ b/macros/src/standard/fungible_token.rs
@@ -3,6 +3,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Expr, Type};
 
+use crate::unitify;
+
 use super::{nep141, nep145, nep148};
 
 #[derive(Debug, FromDeriveInput)]
@@ -53,11 +55,8 @@ pub fn expand(meta: FungibleTokenMeta) -> Result<TokenStream, darling::Error> {
         near_sdk,
     } = meta;
 
-    let all_hooks_or_unit = all_hooks
-        .clone()
-        .unwrap_or_else(|| syn::parse_quote! { () });
-    let force_unregister_hook_or_unit =
-        force_unregister_hook.unwrap_or_else(|| syn::parse_quote! { () });
+    let all_hooks_or_unit = unitify(all_hooks.clone());
+    let force_unregister_hook_or_unit = unitify(force_unregister_hook);
 
     let expand_nep141 = nep141::expand(nep141::Nep141Meta {
         storage_key: core_storage_key,

--- a/macros/src/standard/nep141.rs
+++ b/macros/src/standard/nep141.rs
@@ -84,10 +84,10 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
                 let amount: u128 = amount.into();
 
                 let transfer = Nep141Transfer {
-                    sender_id: &sender_id,
-                    receiver_id: &receiver_id,
+                    sender_id: sender_id.into(),
+                    receiver_id: receiver_id.into(),
                     amount,
-                    memo: memo.as_deref(),
+                    memo: memo.map(Into::into),
                     msg: None,
                     revert: false,
                 };
@@ -118,11 +118,11 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
                 let amount: u128 = amount.into();
 
                 let transfer = Nep141Transfer {
-                    sender_id: &sender_id,
-                    receiver_id: &receiver_id,
+                    sender_id: sender_id.into(),
+                    receiver_id: receiver_id.into(),
                     amount,
-                    memo: memo.as_deref(),
-                    msg: Some(&msg),
+                    memo: memo.map(Into::into),
+                    msg: Some(msg.clone().into()),
                     revert: false,
                 };
 
@@ -134,15 +134,15 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
                     .unwrap_or_else(|| #near_sdk::env::panic_str("Prepaid gas underflow."));
 
                 // Initiating receiver's call and the callback
-                ext_nep141_receiver::ext(transfer.receiver_id.clone())
+                ext_nep141_receiver::ext(transfer.receiver_id.clone().into())
                     .with_static_gas(receiver_gas)
-                    .ft_on_transfer(transfer.sender_id.clone(), transfer.amount.into(), msg.clone())
+                    .ft_on_transfer(transfer.sender_id.clone().into(), transfer.amount.into(), msg)
                     .then(
                         ext_nep141_resolver::ext(#near_sdk::env::current_account_id())
                             .with_static_gas(GAS_FOR_RESOLVE_TRANSFER)
                             .ft_resolve_transfer(
-                                transfer.sender_id.clone(),
-                                transfer.receiver_id.clone(),
+                                transfer.sender_id.clone().into(),
+                                transfer.receiver_id.clone().into(),
                                 transfer.amount.into(),
                             ),
                     )
@@ -190,8 +190,8 @@ pub fn expand(meta: Nep141Meta) -> Result<TokenStream, darling::Error> {
                     if receiver_balance > 0 {
                         let refund_amount = std::cmp::min(receiver_balance, unused_amount);
                         let transfer = Nep141Transfer {
-                            sender_id: &receiver_id,
-                            receiver_id: &sender_id,
+                            sender_id: receiver_id.into(),
+                            receiver_id: sender_id.into(),
                             amount: refund_amount,
                             memo: None,
                             msg: None,

--- a/macros/src/standard/nep148.rs
+++ b/macros/src/standard/nep148.rs
@@ -44,7 +44,7 @@ pub fn expand(meta: Nep148Meta) -> Result<TokenStream, darling::Error> {
 
         #[#near_sdk::near]
         impl #imp #me::standard::nep148::Nep148 for #ident #ty #wher {
-            fn ft_metadata(&self) -> #me::standard::nep148::FungibleTokenMetadata {
+            fn ft_metadata(&self) -> #me::standard::nep148::ContractMetadata {
                 #me::standard::nep148::Nep148Controller::get_metadata(self)
             }
         }

--- a/macros/src/standard/nep178.rs
+++ b/macros/src/standard/nep178.rs
@@ -79,9 +79,9 @@ pub fn expand(meta: Nep178Meta) -> Result<TokenStream, darling::Error> {
                 let predecessor = #near_sdk::env::predecessor_account_id();
 
                 let action = action::Nep178Approve {
-                    token_id: &token_id,
-                    current_owner_id: &predecessor,
-                    account_id: &account_id,
+                    token_id: token_id.clone(),
+                    current_owner_id: predecessor.clone().into(),
+                    account_id: account_id.clone().into(),
                 };
 
                 let approval_id = Nep178Controller::approve(self, &action)
@@ -107,9 +107,9 @@ pub fn expand(meta: Nep178Meta) -> Result<TokenStream, darling::Error> {
                 let predecessor = #near_sdk::env::predecessor_account_id();
 
                 let action = action::Nep178Revoke {
-                    token_id: &token_id,
-                    current_owner_id: &predecessor,
-                    account_id: &account_id,
+                    token_id,
+                    current_owner_id: predecessor.into(),
+                    account_id: account_id.into(),
                 };
 
                 Nep178Controller::revoke(self, &action)
@@ -125,8 +125,8 @@ pub fn expand(meta: Nep178Meta) -> Result<TokenStream, darling::Error> {
                 let predecessor = #near_sdk::env::predecessor_account_id();
 
                 let action = action::Nep178RevokeAll {
-                    token_id: &token_id,
-                    current_owner_id: &predecessor,
+                    token_id,
+                    current_owner_id: predecessor.into(),
                 };
 
                 Nep178Controller::revoke_all(self, &action)

--- a/macros/src/standard/nep297.rs
+++ b/macros/src/standard/nep297.rs
@@ -153,11 +153,11 @@ pub fn expand(meta: Nep297Meta) -> Result<TokenStream, darling::Error> {
         impl #imp #me::standard::nep297::ToEventLog for #ident #ty #wher {
             type Data = #ident #ty;
 
-            fn to_event_log<'__el>(&'__el self) -> #me::standard::nep297::EventLog<&'__el Self> {
+            fn to_event_log<'__el>(&'__el self) -> #me::standard::nep297::EventLog<&'__el Self::Data> {
                 #me::standard::nep297::EventLog {
-                    standard: #standard,
-                    version: #version,
-                    event: #event,
+                    standard: #standard.into(),
+                    version: #version.into(),
+                    event: #event.into(),
                     data: self,
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub mod ft {
                 StorageBalance, StorageBalanceBounds,
             },
             nep148::{
-                self, ext_nep148, FungibleTokenMetadata, Nep148, Nep148Controller,
+                self, ext_nep148, ContractMetadata, Nep148, Nep148Controller,
                 Nep148ControllerInternal,
             },
         },

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -49,7 +49,7 @@ const NO_PROPOSED_OWNER_FAIL_MESSAGE: &str = "No proposed owner";
     crate = "crate",
     macros = "near_sdk_contract_tools_macros"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum OwnerEvent {
     /// Emitted when the current owner of the contract changes
     Transfer {

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -49,7 +49,7 @@ const NO_PROPOSED_OWNER_FAIL_MESSAGE: &str = "No proposed owner";
     crate = "crate",
     macros = "near_sdk_contract_tools_macros"
 )]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum OwnerEvent {
     /// Emitted when the current owner of the contract changes
     Transfer {

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -36,7 +36,7 @@ const PAUSED_FAIL_MESSAGE: &str = "Disallowed while contract is paused";
     crate = "crate",
     macros = "near_sdk_contract_tools_macros"
 )]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum PauseEvent {
     /// Emitted when the contract is paused
     Pause,

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -36,7 +36,7 @@ const PAUSED_FAIL_MESSAGE: &str = "Disallowed while contract is paused";
     crate = "crate",
     macros = "near_sdk_contract_tools_macros"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PauseEvent {
     /// Emitted when the contract is paused
     Pause,

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -2,7 +2,7 @@
 //!
 //! Makes it easy to create and manage storage keys and avoid unnecessary
 //! writes to contract storage. This reduces transaction IO  and saves on gas.
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::Deref};
 
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
@@ -95,9 +95,18 @@ impl<T> Slot<T> {
 }
 
 impl<T: BorshSerialize> Slot<T> {
-    /// Writes a value to the managed storage slot
+    /// Writes a value to the managed storage slot.
     pub fn write(&mut self, value: &T) -> bool {
-        self.write_raw(&{ borsh::to_vec(&value) }.unwrap())
+        self.write_raw(&borsh::to_vec(value).unwrap())
+    }
+
+    /// Writes a value to the managed storage slot which is dereferenced from
+    /// the target type.
+    pub fn write_deref<U: BorshSerialize + ?Sized>(&mut self, value: &U) -> bool
+    where
+        T: Deref<Target = U>,
+    {
+        self.write_raw(&borsh::to_vec(value).unwrap())
     }
 
     /// If the given value is `Some(T)`, writes `T` to storage. Otherwise,

--- a/src/standard/nep141/event.rs
+++ b/src/standard/nep141/event.rs
@@ -17,7 +17,7 @@ use near_sdk_contract_tools_macros::event;
     standard = "nep141",
     version = "1.0.0"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Nep141Event<'a> {
     /// Token mint event. Emitted when tokens are created and total_supply is
     /// increased.

--- a/src/standard/nep141/event.rs
+++ b/src/standard/nep141/event.rs
@@ -17,7 +17,7 @@ use near_sdk_contract_tools_macros::event;
     standard = "nep141",
     version = "1.0.0"
 )]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Nep141Event<'a> {
     /// Token mint event. Emitted when tokens are created and total_supply is
     /// increased.

--- a/src/standard/nep141/event.rs
+++ b/src/standard/nep141/event.rs
@@ -1,5 +1,13 @@
 //! NEP-141 standard events for minting, burning, and transferring tokens.
 
+use std::borrow::Cow;
+
+use near_sdk::{
+    json_types::U128,
+    serde::{Deserialize, Serialize},
+    AccountIdRef,
+};
+
 use near_sdk_contract_tools_macros::event;
 
 /// NEP-141 standard events for minting, burning, and transferring tokens.
@@ -10,60 +18,59 @@ use near_sdk_contract_tools_macros::event;
     version = "1.0.0"
 )]
 #[derive(Debug, Clone)]
-pub enum Nep141Event {
+pub enum Nep141Event<'a> {
     /// Token mint event. Emitted when tokens are created and total_supply is
     /// increased.
-    FtMint(Vec<FtMintData>),
+    FtMint(Vec<FtMintData<'a>>),
 
     /// Token transfer event. Emitted when tokens are transferred between two
     /// accounts. No change to total_supply.
-    FtTransfer(Vec<FtTransferData>),
+    FtTransfer(Vec<FtTransferData<'a>>),
 
     /// Token burn event. Emitted when tokens are burned (removed from supply).
     /// Decrease in total_supply.
-    FtBurn(Vec<FtBurnData>),
+    FtBurn(Vec<FtBurnData<'a>>),
 }
-use near_sdk::{json_types::U128, serde::Serialize, AccountId};
 
 /// Individual mint metadata
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct FtMintData {
+pub struct FtMintData<'a> {
     /// Address to which new tokens were minted
-    pub owner_id: AccountId,
+    pub owner_id: Cow<'a, AccountIdRef>,
     /// Amount of minted tokens
     pub amount: U128,
     /// Optional note
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// Individual transfer metadata
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct FtTransferData {
+pub struct FtTransferData<'a> {
     /// Account ID of the sender
-    pub old_owner_id: AccountId,
+    pub old_owner_id: Cow<'a, AccountIdRef>,
     /// Account ID of the receiver
-    pub new_owner_id: AccountId,
+    pub new_owner_id: Cow<'a, AccountIdRef>,
     /// Amount of transferred tokens
     pub amount: U128,
     /// Optional note
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// Individual burn metadata
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct FtBurnData {
+pub struct FtBurnData<'a> {
     /// Account ID from which tokens were burned
-    pub owner_id: AccountId,
+    pub owner_id: Cow<'a, AccountIdRef>,
     /// Amount of burned tokens
     pub amount: U128,
     /// Optional note
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 #[cfg(test)]
@@ -75,7 +82,7 @@ mod tests {
     fn mint() {
         assert_eq!(
             Nep141Event::FtMint(vec![FtMintData {
-                owner_id: "foundation.near".parse().unwrap(),
+                owner_id: AccountIdRef::new_or_panic("foundation.near").into(),
                 amount: 500u128.into(),
                 memo: None,
             }])
@@ -89,16 +96,16 @@ mod tests {
         assert_eq!(
             Nep141Event::FtTransfer(vec![
                 FtTransferData {
-                    old_owner_id: "from.near".parse().unwrap(),
-                    new_owner_id: "to.near".parse().unwrap(),
+                    old_owner_id: AccountIdRef::new_or_panic("from.near").into(),
+                    new_owner_id: AccountIdRef::new_or_panic("to.near").into(),
                     amount: 42u128.into(),
-                    memo: Some("hi hello bonjour".to_string()),
+                    memo: Some("hi hello bonjour".into()),
                 },
                 FtTransferData {
-                    old_owner_id: "user1.near".parse().unwrap(),
-                    new_owner_id: "user2.near".parse().unwrap(),
+                    old_owner_id: AccountIdRef::new_or_panic("user1.near").into(),
+                    new_owner_id: AccountIdRef::new_or_panic("user2.near").into(),
                     amount: 7500u128.into(),
-                    memo: None
+                    memo: None,
                 },
             ])
             .to_event_string(),
@@ -110,7 +117,7 @@ mod tests {
     fn burn() {
         assert_eq!(
             Nep141Event::FtBurn(vec![FtBurnData {
-                owner_id: "foundation.near".parse().unwrap(),
+                owner_id: AccountIdRef::new_or_panic("foundation.near").into(),
                 amount: 100u128.into(),
                 memo: None,
             }])

--- a/src/standard/nep141/hooks.rs
+++ b/src/standard/nep141/hooks.rs
@@ -17,12 +17,12 @@ impl<C: Nep141Controller + Nep141ControllerInternal> Hook<C, Nep145ForceUnregist
     ) -> R {
         let r = f(contract);
 
-        let balance = contract.balance_of(args.account_id);
+        let balance = contract.balance_of(&args.account_id);
         contract
             .burn(&Nep141Burn {
                 amount: balance,
-                owner_id: args.account_id,
-                memo: Some("storage forced unregistration"),
+                owner_id: args.account_id.clone(),
+                memo: Some("storage forced unregistration".into()),
             })
             .unwrap_or_else(|e| {
                 near_sdk::env::panic_str(&format!(
@@ -30,7 +30,7 @@ impl<C: Nep141Controller + Nep141ControllerInternal> Hook<C, Nep145ForceUnregist
                 ))
             });
 
-        <C as Nep141ControllerInternal>::slot_account(args.account_id).remove();
+        <C as Nep141ControllerInternal>::slot_account(&args.account_id).remove();
 
         r
     }

--- a/src/standard/nep141/hooks.rs
+++ b/src/standard/nep141/hooks.rs
@@ -19,11 +19,10 @@ impl<C: Nep141Controller + Nep141ControllerInternal> Hook<C, Nep145ForceUnregist
 
         let balance = contract.balance_of(&args.account_id);
         contract
-            .burn(&Nep141Burn {
-                amount: balance,
-                owner_id: args.account_id.clone(),
-                memo: Some("storage forced unregistration".into()),
-            })
+            .burn(
+                &Nep141Burn::new(balance, args.account_id.clone())
+                    .memo("storage forced unregistration"),
+            )
             .unwrap_or_else(|e| {
                 near_sdk::env::panic_str(&format!(
                     "Failed to burn tokens during forced unregistration: {e}",

--- a/src/standard/nep141/mod.rs
+++ b/src/standard/nep141/mod.rs
@@ -53,6 +53,38 @@ pub struct Nep141Transfer<'a> {
 }
 
 impl<'a> Nep141Transfer<'a> {
+    /// Create a new transfer action.
+    pub fn new(
+        amount: u128,
+        sender_id: impl Into<Cow<'a, AccountIdRef>>,
+        receiver_id: impl Into<Cow<'a, AccountIdRef>>,
+    ) -> Self {
+        Self {
+            sender_id: sender_id.into(),
+            receiver_id: receiver_id.into(),
+            amount,
+            memo: None,
+            msg: None,
+            revert: false,
+        }
+    }
+
+    /// Add a memo string.
+    pub fn memo(self, memo: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            memo: Some(memo.into()),
+            ..self
+        }
+    }
+
+    /// Add a message string.
+    pub fn msg(self, msg: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            msg: Some(msg.into()),
+            ..self
+        }
+    }
+
     /// Returns `true` if this transfer comes from a `ft_transfer_call`
     /// call, `false` otherwise.
     pub fn is_transfer_call(&self) -> bool {
@@ -72,6 +104,25 @@ pub struct Nep141Mint<'a> {
     pub memo: Option<Cow<'a, str>>,
 }
 
+impl<'a> Nep141Mint<'a> {
+    /// Create a new mint action.
+    pub fn new(amount: u128, receiver_id: impl Into<Cow<'a, AccountIdRef>>) -> Self {
+        Self {
+            amount,
+            receiver_id: receiver_id.into(),
+            memo: None,
+        }
+    }
+
+    /// Add a memo string.
+    pub fn memo(self, memo: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            memo: Some(memo.into()),
+            ..self
+        }
+    }
+}
+
 /// Describes a burn operation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[near]
@@ -82,6 +133,25 @@ pub struct Nep141Burn<'a> {
     pub owner_id: Cow<'a, AccountIdRef>,
     /// Optional memo string.
     pub memo: Option<Cow<'a, str>>,
+}
+
+impl<'a> Nep141Burn<'a> {
+    /// Create a new burn action.
+    pub fn new(amount: u128, owner_id: impl Into<Cow<'a, AccountIdRef>>) -> Self {
+        Self {
+            amount,
+            owner_id: owner_id.into(),
+            memo: None,
+        }
+    }
+
+    /// Add a memo string.
+    pub fn memo(self, memo: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            memo: Some(memo.into()),
+            ..self
+        }
+    }
 }
 
 /// Internal functions for [`Nep141Controller`]. Using these methods may result in unexpected behavior.

--- a/src/standard/nep145/hooks.rs
+++ b/src/standard/nep145/hooks.rs
@@ -1,6 +1,6 @@
 //! Hooks to integrate NEP-145 with other components.
 
-use near_sdk::{env, AccountId};
+use near_sdk::{env, AccountIdRef};
 
 use crate::{
     hook::Hook,
@@ -12,7 +12,7 @@ use crate::{
 
 use super::Nep145Controller;
 
-fn require_registration(contract: &impl Nep145Controller, account_id: &AccountId) {
+fn require_registration(contract: &impl Nep145Controller, account_id: &AccountIdRef) {
     contract
         .get_storage_balance(account_id)
         .unwrap_or_else(|e| env::panic_str(&e.to_string()));
@@ -20,7 +20,7 @@ fn require_registration(contract: &impl Nep145Controller, account_id: &AccountId
 
 fn apply_storage_accounting_hook<C: Nep145Controller, R>(
     contract: &mut C,
-    account_id: &AccountId,
+    account_id: &AccountIdRef,
     f: impl FnOnce(&mut C) -> R,
 ) -> R {
     let storage_usage_start = env::storage_usage();
@@ -49,13 +49,13 @@ pub struct Nep141StorageAccountingHook;
 
 impl<C: Nep145Controller> Hook<C, Nep141Mint<'_>> for Nep141StorageAccountingHook {
     fn hook<R>(contract: &mut C, action: &Nep141Mint<'_>, f: impl FnOnce(&mut C) -> R) -> R {
-        apply_storage_accounting_hook(contract, action.receiver_id, f)
+        apply_storage_accounting_hook(contract, &action.receiver_id, f)
     }
 }
 
 impl<C: Nep145Controller> Hook<C, Nep141Transfer<'_>> for Nep141StorageAccountingHook {
     fn hook<R>(contract: &mut C, action: &Nep141Transfer<'_>, f: impl FnOnce(&mut C) -> R) -> R {
-        apply_storage_accounting_hook(contract, action.receiver_id, f)
+        apply_storage_accounting_hook(contract, &action.receiver_id, f)
     }
 }
 
@@ -70,13 +70,13 @@ pub struct Nep171StorageAccountingHook;
 
 impl<C: Nep145Controller> Hook<C, Nep171Mint<'_>> for Nep171StorageAccountingHook {
     fn hook<R>(contract: &mut C, action: &Nep171Mint<'_>, f: impl FnOnce(&mut C) -> R) -> R {
-        apply_storage_accounting_hook(contract, action.receiver_id, f)
+        apply_storage_accounting_hook(contract, &action.receiver_id, f)
     }
 }
 
 impl<C: Nep145Controller> Hook<C, Nep171Transfer<'_>> for Nep171StorageAccountingHook {
     fn hook<R>(contract: &mut C, action: &Nep171Transfer<'_>, f: impl FnOnce(&mut C) -> R) -> R {
-        apply_storage_accounting_hook(contract, action.receiver_id, f)
+        apply_storage_accounting_hook(contract, &action.receiver_id, f)
     }
 }
 

--- a/src/standard/nep148.rs
+++ b/src/standard/nep148.rs
@@ -15,7 +15,7 @@ pub const ERR_METADATA_UNSET: &str = "NEP-148 metadata is not set";
 /// NEP-148-compatible metadata struct
 #[derive(Eq, PartialEq, Clone, Debug)]
 #[near(serializers = [borsh, json])]
-pub struct FungibleTokenMetadata {
+pub struct ContractMetadata {
     /// Version of the NEP-148 spec
     pub spec: String,
     /// Human-friendly name of the token contract
@@ -35,7 +35,7 @@ pub struct FungibleTokenMetadata {
     pub decimals: u8,
 }
 
-impl FungibleTokenMetadata {
+impl ContractMetadata {
     /// Creates a new metadata struct.
     pub fn new(name: String, symbol: String, decimals: u8) -> Self {
         Self {
@@ -106,7 +106,7 @@ pub trait Nep148ControllerInternal {
     }
 
     /// Returns the storage slot for NEP-148 metadata.
-    fn metadata() -> Slot<FungibleTokenMetadata> {
+    fn metadata() -> Slot<ContractMetadata> {
         Self::root().field(StorageKey::Metadata)
     }
 }
@@ -118,20 +118,20 @@ pub trait Nep148Controller {
     /// # Panics
     ///
     /// Panics if the metadata has not been set.
-    fn get_metadata(&self) -> FungibleTokenMetadata;
+    fn get_metadata(&self) -> ContractMetadata;
 
     /// Sets the metadata struct for this contract.
-    fn set_metadata(&mut self, metadata: &FungibleTokenMetadata);
+    fn set_metadata(&mut self, metadata: &ContractMetadata);
 }
 
 impl<T: Nep148ControllerInternal> Nep148Controller for T {
-    fn get_metadata(&self) -> FungibleTokenMetadata {
+    fn get_metadata(&self) -> ContractMetadata {
         Self::metadata()
             .read()
             .unwrap_or_else(|| env::panic_str(ERR_METADATA_UNSET))
     }
 
-    fn set_metadata(&mut self, metadata: &FungibleTokenMetadata) {
+    fn set_metadata(&mut self, metadata: &ContractMetadata) {
         Self::metadata().set(Some(metadata));
     }
 }
@@ -141,12 +141,12 @@ mod ext {
 
     use near_sdk::ext_contract;
 
-    use super::FungibleTokenMetadata;
+    use super::ContractMetadata;
 
     /// Contract that supports the NEP-148 metadata standard
     #[ext_contract(ext_nep148)]
     pub trait Nep148 {
         /// Returns the metadata struct for this contract.
-        fn ft_metadata(&self) -> FungibleTokenMetadata;
+        fn ft_metadata(&self) -> ContractMetadata;
     }
 }

--- a/src/standard/nep171/action.rs
+++ b/src/standard/nep171/action.rs
@@ -3,53 +3,51 @@
 //! Used when calling various functions on [`Nep171Controller`]. Also used when
 //! implementing [`Hook`]s for the NEP-171 component.
 
+use std::borrow::Cow;
+
 use super::*;
-use near_sdk::{borsh::BorshSerialize, serde::Serialize};
 
 /// NEP-171 mint action.
-#[derive(Serialize, BorshSerialize, Clone, Debug, PartialEq, Eq)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near]
 pub struct Nep171Mint<'a> {
     /// Token IDs to mint.
-    pub token_ids: &'a [TokenId],
+    pub token_ids: Vec<TokenId>,
     /// Account ID of the receiver.
-    pub receiver_id: &'a AccountId,
+    pub receiver_id: Cow<'a, AccountIdRef>,
     /// Optional memo string.
-    pub memo: Option<&'a str>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// NEP-171 burn action.
-#[derive(Serialize, BorshSerialize, Clone, Debug, PartialEq, Eq)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near]
 pub struct Nep171Burn<'a> {
     /// Token IDs to burn.
-    pub token_ids: &'a [TokenId],
+    pub token_ids: Vec<TokenId>,
     /// Account ID of the owner.
-    pub owner_id: &'a AccountId,
+    pub owner_id: Cow<'a, AccountIdRef>,
     /// Optional memo string.
-    pub memo: Option<&'a str>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// Transfer metadata generic over both types of transfer (`nft_transfer` and
 /// `nft_transfer_call`).
-#[derive(Serialize, BorshSerialize, PartialEq, Eq, Clone, Debug, Hash)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[near]
 pub struct Nep171Transfer<'a> {
     /// Why is this sender allowed to perform this transfer?
     pub authorization: Nep171TransferAuthorization,
     /// Sending account ID.
-    pub sender_id: &'a AccountId,
+    pub sender_id: Cow<'a, AccountIdRef>,
     /// Receiving account ID.
-    pub receiver_id: &'a AccountId,
+    pub receiver_id: Cow<'a, AccountIdRef>,
     /// Token ID.
-    pub token_id: &'a TokenId,
+    pub token_id: TokenId,
     /// Optional memo string.
-    pub memo: Option<&'a str>,
+    pub memo: Option<Cow<'a, str>>,
     /// Message passed to contract located at `receiver_id` in the case of `nft_transfer_call`.
-    pub msg: Option<&'a str>,
+    pub msg: Option<Cow<'a, str>>,
     /// `true` if the transfer is a revert for a `nft_transfer_call`.
     pub revert: bool,
 }

--- a/src/standard/nep171/action.rs
+++ b/src/standard/nep171/action.rs
@@ -19,6 +19,25 @@ pub struct Nep171Mint<'a> {
     pub memo: Option<Cow<'a, str>>,
 }
 
+impl<'a> Nep171Mint<'a> {
+    /// Create a new mint action.
+    pub fn new(token_ids: Vec<TokenId>, receiver_id: impl Into<Cow<'a, AccountIdRef>>) -> Self {
+        Self {
+            token_ids,
+            receiver_id: receiver_id.into(),
+            memo: None,
+        }
+    }
+
+    /// Add a memo string.
+    pub fn memo(self, memo: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            memo: Some(memo.into()),
+            ..self
+        }
+    }
+}
+
 /// NEP-171 burn action.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[near]
@@ -29,6 +48,25 @@ pub struct Nep171Burn<'a> {
     pub owner_id: Cow<'a, AccountIdRef>,
     /// Optional memo string.
     pub memo: Option<Cow<'a, str>>,
+}
+
+impl<'a> Nep171Burn<'a> {
+    /// Create a new burn action.
+    pub fn new(token_ids: Vec<TokenId>, owner_id: impl Into<Cow<'a, AccountIdRef>>) -> Self {
+        Self {
+            token_ids,
+            owner_id: owner_id.into(),
+            memo: None,
+        }
+    }
+
+    /// Add a memo string.
+    pub fn memo(self, memo: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            memo: Some(memo.into()),
+            ..self
+        }
+    }
 }
 
 /// Transfer metadata generic over both types of transfer (`nft_transfer` and
@@ -50,4 +88,40 @@ pub struct Nep171Transfer<'a> {
     pub msg: Option<Cow<'a, str>>,
     /// `true` if the transfer is a revert for a `nft_transfer_call`.
     pub revert: bool,
+}
+
+impl<'a> Nep171Transfer<'a> {
+    /// Create a new transfer action.
+    pub fn new(
+        token_id: TokenId,
+        sender_id: impl Into<Cow<'a, AccountIdRef>>,
+        receiver_id: impl Into<Cow<'a, AccountIdRef>>,
+        authorization: Nep171TransferAuthorization,
+    ) -> Self {
+        Self {
+            authorization,
+            sender_id: sender_id.into(),
+            receiver_id: receiver_id.into(),
+            token_id,
+            memo: None,
+            msg: None,
+            revert: false,
+        }
+    }
+
+    /// Add a memo string.
+    pub fn memo(self, memo: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            memo: Some(memo.into()),
+            ..self
+        }
+    }
+
+    /// Add a message string.
+    pub fn msg(self, msg: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            msg: Some(msg.into()),
+            ..self
+        }
+    }
 }

--- a/src/standard/nep171/event.rs
+++ b/src/standard/nep171/event.rs
@@ -15,7 +15,7 @@ use near_sdk_contract_tools_macros::event;
     standard = "nep171",
     version = "1.2.0"
 )]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Nep171Event<'a> {
     /// Emitted when a token is newly minted.
     NftMint(Vec<NftMintLog<'a>>),

--- a/src/standard/nep171/event.rs
+++ b/src/standard/nep171/event.rs
@@ -15,7 +15,7 @@ use near_sdk_contract_tools_macros::event;
     standard = "nep171",
     version = "1.2.0"
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Nep171Event<'a> {
     /// Emitted when a token is newly minted.
     NftMint(Vec<NftMintLog<'a>>),

--- a/src/standard/nep171/event.rs
+++ b/src/standard/nep171/event.rs
@@ -1,6 +1,11 @@
 //! Event log metadata & associated structures.
 
-use near_sdk::{serde::Serialize, AccountId};
+use std::borrow::Cow;
+
+use near_sdk::{
+    serde::{Deserialize, Serialize},
+    AccountIdRef,
+};
 use near_sdk_contract_tools_macros::event;
 
 /// NEP-171 standard events.
@@ -11,82 +16,82 @@ use near_sdk_contract_tools_macros::event;
     version = "1.2.0"
 )]
 #[derive(Debug, Clone)]
-pub enum Nep171Event {
+pub enum Nep171Event<'a> {
     /// Emitted when a token is newly minted.
-    NftMint(Vec<NftMintLog>),
+    NftMint(Vec<NftMintLog<'a>>),
     /// Emitted when a token is transferred between two parties.
-    NftTransfer(Vec<NftTransferLog>),
+    NftTransfer(Vec<NftTransferLog<'a>>),
     /// Emitted when a token is burned.
-    NftBurn(Vec<NftBurnLog>),
+    NftBurn(Vec<NftBurnLog<'a>>),
     /// Emitted when the metadata associated with an NFT contract is updated.
-    NftMetadataUpdate(Vec<NftMetadataUpdateLog>),
+    NftMetadataUpdate(Vec<NftMetadataUpdateLog<'a>>),
     /// Emitted when the metadata associated with an NFT contract is updated.
-    ContractMetadataUpdate(Vec<NftContractMetadataUpdateLog>),
+    ContractMetadataUpdate(Vec<NftContractMetadataUpdateLog<'a>>),
 }
 
 /// Tokens minted to a single owner.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct NftMintLog {
+pub struct NftMintLog<'a> {
     /// To whom were the new tokens minted?
-    pub owner_id: AccountId,
+    pub owner_id: Cow<'a, AccountIdRef>,
     /// Which tokens were minted?
-    pub token_ids: Vec<String>,
+    pub token_ids: Vec<Cow<'a, str>>,
     /// Additional mint information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// Tokens are transferred from one account to another.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct NftTransferLog {
+pub struct NftTransferLog<'a> {
     /// NEP-178 authorized account ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub authorized_id: Option<AccountId>,
+    pub authorized_id: Option<Cow<'a, AccountIdRef>>,
     /// Account ID of the previous owner.
-    pub old_owner_id: AccountId,
+    pub old_owner_id: Cow<'a, AccountIdRef>,
     /// Account ID of the new owner.
-    pub new_owner_id: AccountId,
+    pub new_owner_id: Cow<'a, AccountIdRef>,
     /// IDs of the transferred tokens.
-    pub token_ids: Vec<String>,
+    pub token_ids: Vec<Cow<'a, str>>,
     /// Additional transfer information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// Tokens are burned from a single holder.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct NftBurnLog {
+pub struct NftBurnLog<'a> {
     /// What is the ID of the account from which the tokens were burned?
-    pub owner_id: AccountId,
+    pub owner_id: Cow<'a, AccountIdRef>,
     /// IDs of the burned tokens.
-    pub token_ids: Vec<String>,
+    pub token_ids: Vec<Cow<'a, str>>,
     /// NEP-178 authorized account ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub authorized_id: Option<AccountId>,
+    pub authorized_id: Option<Cow<'a, AccountIdRef>>,
     /// Additional burn information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// Token metadata update.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct NftMetadataUpdateLog {
+pub struct NftMetadataUpdateLog<'a> {
     /// IDs of the updated tokens.
-    pub token_ids: Vec<String>,
+    pub token_ids: Vec<Cow<'a, str>>,
     /// Additional update information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }
 
 /// Contract metadata update.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct NftContractMetadataUpdateLog {
+pub struct NftContractMetadataUpdateLog<'a> {
     /// Additional update information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memo: Option<String>,
+    pub memo: Option<Cow<'a, str>>,
 }

--- a/src/standard/nep171/hooks.rs
+++ b/src/standard/nep171/hooks.rs
@@ -24,11 +24,10 @@ where
             contract.with_tokens_for_owner(&action.account_id, |t| t.iter().collect::<Vec<_>>());
 
         contract
-            .burn(&Nep171Burn {
-                token_ids,
-                owner_id: action.account_id.clone(),
-                memo: Some("storage forced unregistration".into()),
-            })
+            .burn(
+                &Nep171Burn::new(token_ids, action.account_id.clone())
+                    .memo("storage forced unregistration"),
+            )
             .unwrap_or_else(|e| {
                 near_sdk::env::panic_str(&format!(
                     "Failed to burn tokens during forced unregistration: {e}",

--- a/src/standard/nep171/hooks.rs
+++ b/src/standard/nep171/hooks.rs
@@ -21,13 +21,13 @@ where
         f: impl FnOnce(&mut C) -> R,
     ) -> R {
         let token_ids =
-            contract.with_tokens_for_owner(action.account_id, |t| t.iter().collect::<Vec<_>>());
+            contract.with_tokens_for_owner(&action.account_id, |t| t.iter().collect::<Vec<_>>());
 
         contract
             .burn(&Nep171Burn {
-                token_ids: &token_ids,
-                owner_id: action.account_id,
-                memo: Some("storage forced unregistration"),
+                token_ids,
+                owner_id: action.account_id.clone(),
+                memo: Some("storage forced unregistration".into()),
             })
             .unwrap_or_else(|e| {
                 near_sdk::env::panic_str(&format!(

--- a/src/standard/nep177.rs
+++ b/src/standard/nep177.rs
@@ -302,11 +302,7 @@ impl<T: Nep177ControllerInternal + Nep171Controller> Nep177Controller for T {
         owner_id: &AccountIdRef,
         metadata: &TokenMetadata,
     ) -> Result<(), Nep171MintError> {
-        self.mint(&Nep171Mint {
-            token_ids: vec![token_id.clone()],
-            receiver_id: owner_id.into(),
-            memo: None,
-        })?;
+        self.mint(&Nep171Mint::new(vec![token_id.clone()], owner_id))?;
         self.set_token_metadata_unchecked(token_id, Some(metadata));
         Ok(())
     }
@@ -316,11 +312,7 @@ impl<T: Nep177ControllerInternal + Nep171Controller> Nep177Controller for T {
         token_id: &TokenId,
         owner_id: &AccountId,
     ) -> Result<(), Nep171BurnError> {
-        self.burn(&Nep171Burn {
-            token_ids: vec![token_id.clone()],
-            owner_id: owner_id.into(),
-            memo: None,
-        })?;
+        self.burn(&Nep171Burn::new(vec![token_id.clone()], owner_id))?;
         self.set_token_metadata_unchecked(token_id, None);
         Ok(())
     }

--- a/src/standard/nep177.rs
+++ b/src/standard/nep177.rs
@@ -3,7 +3,9 @@
 //! Reference: <https://github.com/near/NEPs/blob/master/neps/nep-0177.md>
 use std::error::Error;
 
-use near_sdk::{borsh::BorshSerialize, env, json_types::U64, near, AccountId, BorshStorageKey};
+use near_sdk::{
+    borsh::BorshSerialize, env, json_types::U64, near, AccountId, AccountIdRef, BorshStorageKey,
+};
 use thiserror::Error;
 
 use crate::{
@@ -226,26 +228,30 @@ pub trait Nep177Controller {
     /// Mint a new token with metadata.
     fn mint_with_metadata(
         &mut self,
-        token_id: TokenId,
-        owner_id: AccountId,
+        token_id: &TokenId,
+        owner_id: &AccountIdRef,
         metadata: &TokenMetadata,
     ) -> Result<(), Nep171MintError>;
 
     /// Burn a token with metadata.
     fn burn_with_metadata(
         &mut self,
-        token_id: TokenId,
+        token_id: &TokenId,
         owner_id: &AccountId,
     ) -> Result<(), Nep171BurnError>;
 
     /// Sets the metadata for a token ID without checking whether the token
     /// exists, etc. and emits an [`Nep171Event::NftMetadataUpdate`] event.
-    fn set_token_metadata_unchecked(&mut self, token_id: TokenId, metadata: Option<&TokenMetadata>);
+    fn set_token_metadata_unchecked(
+        &mut self,
+        token_id: &TokenId,
+        metadata: Option<&TokenMetadata>,
+    );
 
     /// Sets the metadata for a token ID and emits an [`Nep171Event::NftMetadataUpdate`] event.
     fn set_token_metadata(
         &mut self,
-        token_id: TokenId,
+        token_id: &TokenId,
         metadata: &TokenMetadata,
     ) -> Result<(), UpdateTokenMetadataError>;
 
@@ -270,14 +276,17 @@ pub enum UpdateTokenMetadataError {
 impl<T: Nep177ControllerInternal + Nep171Controller> Nep177Controller for T {
     fn set_token_metadata(
         &mut self,
-        token_id: TokenId,
+        token_id: &TokenId,
         metadata: &TokenMetadata,
     ) -> Result<(), UpdateTokenMetadataError> {
-        if self.token_owner(&token_id).is_some() {
+        if self.token_owner(token_id).is_some() {
             self.set_token_metadata_unchecked(token_id, Some(metadata));
             Ok(())
         } else {
-            Err(TokenDoesNotExistError { token_id }.into())
+            Err(TokenDoesNotExistError {
+                token_id: token_id.clone(),
+            }
+            .into())
         }
     }
 
@@ -289,47 +298,41 @@ impl<T: Nep177ControllerInternal + Nep171Controller> Nep177Controller for T {
 
     fn mint_with_metadata(
         &mut self,
-        token_id: TokenId,
-        owner_id: AccountId,
+        token_id: &TokenId,
+        owner_id: &AccountIdRef,
         metadata: &TokenMetadata,
     ) -> Result<(), Nep171MintError> {
-        let token_ids = [token_id];
-        let action = Nep171Mint {
-            token_ids: &token_ids,
-            receiver_id: &owner_id,
+        self.mint(&Nep171Mint {
+            token_ids: vec![token_id.clone()],
+            receiver_id: owner_id.into(),
             memo: None,
-        };
-        self.mint(&action)?;
-        let [token_id] = token_ids;
+        })?;
         self.set_token_metadata_unchecked(token_id, Some(metadata));
         Ok(())
     }
 
     fn burn_with_metadata(
         &mut self,
-        token_id: TokenId,
+        token_id: &TokenId,
         owner_id: &AccountId,
     ) -> Result<(), Nep171BurnError> {
-        let token_ids = [token_id];
-        let action = Nep171Burn {
-            token_ids: &token_ids,
-            owner_id,
+        self.burn(&Nep171Burn {
+            token_ids: vec![token_id.clone()],
+            owner_id: owner_id.into(),
             memo: None,
-        };
-        self.burn(&action)?;
-        let [token_id] = token_ids;
+        })?;
         self.set_token_metadata_unchecked(token_id, None);
         Ok(())
     }
 
     fn set_token_metadata_unchecked(
         &mut self,
-        token_id: TokenId,
+        token_id: &TokenId,
         metadata: Option<&TokenMetadata>,
     ) {
-        <Self as Nep177ControllerInternal>::slot_token_metadata(&token_id).set(metadata);
+        <Self as Nep177ControllerInternal>::slot_token_metadata(token_id).set(metadata);
         Nep171Event::NftMetadataUpdate(vec![NftMetadataUpdateLog {
-            token_ids: vec![token_id],
+            token_ids: vec![token_id.into()],
             memo: None,
         }])
         .emit();

--- a/src/standard/nep178/action.rs
+++ b/src/standard/nep178/action.rs
@@ -4,44 +4,40 @@
 //! implementing [`Hook`]s for the NEP-178 component.
 
 use super::*;
-use near_sdk::{borsh::BorshSerialize, serde::Serialize};
 
 /// NEP-178 approve action.
-#[derive(Serialize, BorshSerialize, Clone, Debug, PartialEq, Eq)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near]
 pub struct Nep178Approve<'a> {
     /// Token ID that the target account is being approved for.
-    pub token_id: &'a TokenId,
+    pub token_id: TokenId,
     /// Account ID of the current owner of the token.
-    pub current_owner_id: &'a AccountId,
+    pub current_owner_id: Cow<'a, AccountIdRef>,
     /// Account ID of the target account. This account will be able to
     /// transfer the token.
-    pub account_id: &'a AccountId,
+    pub account_id: Cow<'a, AccountIdRef>,
 }
 
 /// NEP-178 revoke action.
-#[derive(Serialize, BorshSerialize, Clone, Debug, PartialEq, Eq)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near]
 pub struct Nep178Revoke<'a> {
     /// Token ID that the target account will no longer be able to transfer
     /// (approval revoked).
-    pub token_id: &'a TokenId,
+    pub token_id: TokenId,
     /// Account ID of the current owner of the token.
-    pub current_owner_id: &'a AccountId,
+    pub current_owner_id: Cow<'a, AccountIdRef>,
     /// Account ID of the target account. This account will no longer be able
     /// to transfer the token.
-    pub account_id: &'a AccountId,
+    pub account_id: Cow<'a, AccountIdRef>,
 }
 
 /// NEP-178 revoke all action.
-#[derive(Serialize, BorshSerialize, Clone, Debug, PartialEq, Eq)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near]
 pub struct Nep178RevokeAll<'a> {
     /// Token ID that all approvals will be revoked from.
-    pub token_id: &'a TokenId,
+    pub token_id: TokenId,
     /// Account ID of the current owner of the token.
-    pub current_owner_id: &'a AccountId,
+    pub current_owner_id: Cow<'a, AccountIdRef>,
 }

--- a/src/standard/nep297.rs
+++ b/src/standard/nep297.rs
@@ -1,12 +1,15 @@
 //! Helpers for `#[derive(near_sdk_contract_tools::Nep297)]`
 
-use near_sdk::{serde::Serialize, serde_json};
+use std::borrow::Cow;
+
+use near_sdk::{
+    serde::{self, Deserialize, Serialize},
+    serde_json,
+};
 
 /// Emit events according to the [NEP-297 event standard](https://nomicon.io/Standards/EventsFormat).
 ///
 /// # Examples
-///
-/// ## Normal events
 ///
 /// ```
 /// use near_sdk_contract_tools::event;
@@ -27,10 +30,10 @@ use near_sdk::{serde::Serialize, serde_json};
 /// e.emit();
 /// ```
 pub trait Event {
-    /// Converts the event into an NEP-297 event-formatted string
+    /// Converts the event into an NEP-297 event-formatted string.
     fn to_event_string(&self) -> String;
 
-    /// Emits the event string to the blockchain
+    /// Emits the event string to the blockchain.
     fn emit(&self);
 }
 
@@ -60,26 +63,92 @@ where
     }
 }
 
-/// This type can be converted into an [`EventLog`] struct
+/// This type can be converted into an [`EventLog`] struct.
 pub trait ToEventLog {
-    /// Metadata associated with the event
-    type Data: ?Sized;
+    /// Metadata associated with the event.
+    type Data;
 
-    /// Retrieves the event log before serialization
+    /// Retrieves the event log before serialization.
     fn to_event_log(&self) -> EventLog<&Self::Data>;
 }
 
 /// NEP-297 Event Log Data
 /// <https://github.com/near/NEPs/blob/master/neps/nep-0297.md#specification>
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(crate = "near_sdk::serde")]
-pub struct EventLog<T> {
-    /// Name of the event standard, e.g. "nep171"
-    pub standard: &'static str,
-    /// Version of the standard, e.g. "1.0.0"
-    pub version: &'static str,
-    /// Name of the particular event, e.g. "nft_mint", "ft_transfer"
-    pub event: &'static str,
-    /// Data type of the event metadata
+pub struct EventLog<'a, T> {
+    /// Name of the event standard, e.g. `"nep171"`.
+    pub standard: Cow<'a, str>,
+    /// Version of the standard, e.g. `"1.0.0"`.
+    pub version: Cow<'a, str>,
+    /// Name of the particular event, e.g. `"nft_mint"`, `"ft_transfer"`.
+    pub event: Cow<'a, str>,
+    /// Data type of the event metadata.
     pub data: T,
+}
+
+impl<'de, T: Deserialize<'de>> EventLog<'de, T> {
+    /// Deserializes an event log from a string.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if the string is not a valid event log. A valid event
+    /// log begins with the string `"EVENT_JSON:"`, and is followed by a JSON
+    /// string.
+    pub fn from_event_log_string(s: &'de str) -> Result<Self, serde::de::value::Error> {
+        let data_str = s
+            .strip_prefix("EVENT_JSON:")
+            .ok_or(serde::de::Error::custom(serde::de::Unexpected::Str(
+                "EVENT_JSON:",
+            )))?;
+        let data =
+            serde_json::from_str::<EventLog<T>>(data_str).map_err(serde::de::Error::custom)?;
+        let x = Some(1);
+        x.as_ref();
+        Ok(data)
+    }
+
+    /// Converts the event log into a borrowed reference.
+    pub fn as_ref(&self) -> EventLog<&T> {
+        EventLog {
+            standard: Cow::Borrowed(&self.standard),
+            version: Cow::Borrowed(&self.version),
+            event: Cow::Borrowed(&self.event),
+            data: &self.data,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_and_from_event_log() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct MyEvent;
+
+        impl ToEventLog for MyEvent {
+            type Data = u32;
+
+            fn to_event_log(&self) -> EventLog<&u32> {
+                EventLog {
+                    standard: "nep171".into(),
+                    version: "1.0.0".into(),
+                    event: "nft_mint".into(),
+                    data: &1,
+                }
+            }
+        }
+
+        let event = MyEvent;
+
+        let string = event.to_event_string();
+
+        assert_eq!(string, "EVENT_JSON:{\"standard\":\"nep171\",\"version\":\"1.0.0\",\"event\":\"nft_mint\",\"data\":1}");
+
+        let from_event_log_str = EventLog::<u32>::from_event_log_string(&string).unwrap();
+
+        assert_eq!(from_event_log_str.as_ref(), event.to_event_log());
+    }
 }

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -412,7 +412,7 @@ mod pausable_fungible_token {
         pub fn new() -> Self {
             let mut contract = Self { storage_usage: 0 };
 
-            contract.set_metadata(&FungibleTokenMetadata::new(
+            contract.set_metadata(&ContractMetadata::new(
                 "Pausable Fungible Token".into(),
                 "PFT".into(),
                 18,

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -530,7 +530,7 @@ mod owned_fungible_token {
                 self,
                 &Nep141Mint {
                     amount: amount.into(),
-                    receiver_id: &env::predecessor_account_id(),
+                    receiver_id: env::predecessor_account_id().into(),
                     memo: None,
                 },
             )

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -528,11 +528,7 @@ mod owned_fungible_token {
         pub fn mint(&mut self, amount: U128) {
             Nep141Controller::mint(
                 self,
-                &Nep141Mint {
-                    amount: amount.into(),
-                    receiver_id: env::predecessor_account_id().into(),
-                    memo: None,
-                },
+                &Nep141Mint::new(amount.0, env::predecessor_account_id()),
             )
             .unwrap();
         }

--- a/tests/macros/standard/fungible_token.rs
+++ b/tests/macros/standard/fungible_token.rs
@@ -12,7 +12,7 @@ impl MyFungibleTokenContract {
         let mut contract = Self {};
 
         contract.set_metadata(
-            &FungibleTokenMetadata::new("My Fungible Token".into(), "MYFT".into(), 24)
+            &ContractMetadata::new("My Fungible Token".into(), "MYFT".into(), 24)
                 .icon("https://example.com/icon.png".into())
                 .reference("https://example.com/metadata.json".into())
                 .reference_hash(Base64VecU8::from([97, 115, 100, 102].to_vec())),

--- a/tests/macros/standard/nep141.rs
+++ b/tests/macros/standard/nep141.rs
@@ -96,8 +96,8 @@ fn nep141_transfer() {
         ft.transfers.pop(),
         Some(
             borsh::to_vec(&Nep141Transfer {
-                sender_id: &alice,
-                receiver_id: &bob,
+                sender_id: alice.clone().into(),
+                receiver_id: bob.clone().into(),
                 amount: 50,
                 memo: None,
                 msg: None,

--- a/tests/macros/standard/nep141.rs
+++ b/tests/macros/standard/nep141.rs
@@ -94,24 +94,14 @@ fn nep141_transfer() {
 
     assert_eq!(
         ft.transfers.pop(),
-        Some(
-            borsh::to_vec(&Nep141Transfer {
-                sender_id: alice.clone().into(),
-                receiver_id: bob.clone().into(),
-                amount: 50,
-                memo: None,
-                msg: None,
-                revert: false,
-            })
-            .unwrap()
-        )
+        Some(borsh::to_vec(&Nep141Transfer::new(50, alice.clone(), bob.clone())).unwrap())
     );
 
     let expected_hook_execution_order = vec!["before_transfer", "after_transfer"];
     let actual_hook_execution_order = ft.hooks.to_vec();
     assert_eq!(expected_hook_execution_order, actual_hook_execution_order);
 
-    assert_eq!(ft.ft_balance_of(alice.clone()).0, 50);
-    assert_eq!(ft.ft_balance_of(bob.clone()).0, 70);
+    assert_eq!(ft.ft_balance_of(alice).0, 50);
+    assert_eq!(ft.ft_balance_of(bob).0, 70);
     assert_eq!(ft.ft_total_supply().0, 120);
 }

--- a/tests/macros/standard/nep148.rs
+++ b/tests/macros/standard/nep148.rs
@@ -12,7 +12,7 @@ impl DerivesFTMetadata {
         let mut contract = Self {};
 
         contract.set_metadata(
-            &FungibleTokenMetadata::new("Test Fungible Token".into(), "TFT".into(), 18)
+            &ContractMetadata::new("Test Fungible Token".into(), "TFT".into(), 18)
                 .icon("https://example.com/icon.png".into())
                 .reference("https://example.com/metadata.json".into())
                 .reference_hash(Base64VecU8::from([97, 115, 100, 102].to_vec())),

--- a/tests/macros/standard/nep171/hooks.rs
+++ b/tests/macros/standard/nep171/hooks.rs
@@ -11,7 +11,7 @@ pub struct Contract {
 impl Hook<Contract, Nep171Transfer<'_>> for Contract {
     fn hook<R>(
         contract: &mut Contract,
-        args: &Nep171Transfer<'_>,
+        args: &Nep171Transfer,
         f: impl FnOnce(&mut Contract) -> R,
     ) -> R {
         log!(

--- a/tests/macros/standard/nep171/manual_integration.rs
+++ b/tests/macros/standard/nep171/manual_integration.rs
@@ -41,7 +41,7 @@ impl Contract {
     pub fn new() -> Self {
         let mut contract = Self { next_token_id: 0 };
 
-        contract.set_contract_metadata(nep177::ContractMetadata::new(
+        contract.set_contract_metadata(&nep177::ContractMetadata::new(
             "My NFT".to_string(),
             "MYNFT".to_string(),
             None,
@@ -61,7 +61,7 @@ impl Contract {
             self,
             token_id.clone(),
             env::predecessor_account_id(),
-            nep177::TokenMetadata::new()
+            &nep177::TokenMetadata::new()
                 .title(format!("Token {token_id}"))
                 .description(format!("This is token {token_id}.")),
         )

--- a/tests/macros/standard/nep171/manual_integration.rs
+++ b/tests/macros/standard/nep171/manual_integration.rs
@@ -59,8 +59,8 @@ impl Contract {
         self.next_token_id += 1;
         Nep177Controller::mint_with_metadata(
             self,
-            token_id.clone(),
-            env::predecessor_account_id(),
+            &token_id,
+            &env::predecessor_account_id(),
             &nep177::TokenMetadata::new()
                 .title(format!("Token {token_id}"))
                 .description(format!("This is token {token_id}.")),

--- a/tests/macros/standard/nep171/mod.rs
+++ b/tests/macros/standard/nep171/mod.rs
@@ -49,12 +49,8 @@ mod full_no_hooks {
         Nep145Controller::deposit_to_storage_account(&mut n, &alice, NearToken::from_near(1))
             .unwrap();
 
-        n.mint_with_metadata(
-            token_id.clone(),
-            alice,
-            &TokenMetadata::new().title("Title"),
-        )
-        .unwrap();
+        n.mint_with_metadata(&token_id, &alice, &TokenMetadata::new().title("Title"))
+            .unwrap();
 
         let nft_tok = n.nft_token(token_id);
         dbg!(nft_tok);
@@ -100,8 +96,8 @@ impl NonFungibleToken {
 
     pub fn mint(&mut self, token_id: TokenId, receiver_id: AccountId) {
         let action = Nep171Mint {
-            token_ids: &[token_id],
-            receiver_id: &receiver_id,
+            token_ids: vec![token_id],
+            receiver_id: receiver_id.into(),
             memo: None,
         };
         Nep171Controller::mint(self, &action).unwrap_or_else(|e| {
@@ -174,9 +170,9 @@ mod tests {
             vec![Nep171Event::NftTransfer(vec![NftTransferLog {
                 memo: None,
                 authorized_id: None,
-                old_owner_id: account_alice.clone(),
-                new_owner_id: account_bob.clone(),
-                token_ids: vec![token_id.to_string()]
+                old_owner_id: account_alice.into(),
+                new_owner_id: account_bob.into(),
+                token_ids: vec![token_id.into()]
             }])
             .to_event_string()]
         );

--- a/tests/macros/standard/nep171/mod.rs
+++ b/tests/macros/standard/nep171/mod.rs
@@ -95,14 +95,11 @@ impl NonFungibleToken {
     }
 
     pub fn mint(&mut self, token_id: TokenId, receiver_id: AccountId) {
-        let action = Nep171Mint {
-            token_ids: vec![token_id],
-            receiver_id: receiver_id.into(),
-            memo: None,
-        };
-        Nep171Controller::mint(self, &action).unwrap_or_else(|e| {
-            env::panic_str(&format!("Mint failed: {e:?}"));
-        });
+        Nep171Controller::mint(self, &Nep171Mint::new(vec![token_id], receiver_id)).unwrap_or_else(
+            |e| {
+                env::panic_str(&format!("Mint failed: {e:?}"));
+            },
+        );
     }
 }
 

--- a/tests/macros/standard/nep171/mod.rs
+++ b/tests/macros/standard/nep171/mod.rs
@@ -49,8 +49,12 @@ mod full_no_hooks {
         Nep145Controller::deposit_to_storage_account(&mut n, &alice, NearToken::from_near(1))
             .unwrap();
 
-        n.mint_with_metadata(token_id.clone(), alice, TokenMetadata::new().title("Title"))
-            .unwrap();
+        n.mint_with_metadata(
+            token_id.clone(),
+            alice,
+            &TokenMetadata::new().title("Title"),
+        )
+        .unwrap();
 
         let nft_tok = n.nft_token(token_id);
         dbg!(nft_tok);

--- a/tests/macros/standard/nep171/no_hooks.rs
+++ b/tests/macros/standard/nep171/no_hooks.rs
@@ -13,16 +13,13 @@ impl Contract {
         let token_id = format!("token_{}", self.next_token_id);
         self.next_token_id += 1;
 
-        let token_ids = [token_id];
         let action = Nep171Mint {
-            token_ids: &token_ids,
-            receiver_id: &env::predecessor_account_id(),
+            token_ids: vec![token_id.clone()],
+            receiver_id: env::predecessor_account_id().into(),
             memo: None,
         };
         Nep171Controller::mint(self, &action)
             .unwrap_or_else(|e| env::panic_str(&format!("Minting failed: {e}")));
-
-        let [token_id] = token_ids;
 
         token_id
     }

--- a/tests/macros/standard/nep171/no_hooks.rs
+++ b/tests/macros/standard/nep171/no_hooks.rs
@@ -13,13 +13,11 @@ impl Contract {
         let token_id = format!("token_{}", self.next_token_id);
         self.next_token_id += 1;
 
-        let action = Nep171Mint {
-            token_ids: vec![token_id.clone()],
-            receiver_id: env::predecessor_account_id().into(),
-            memo: None,
-        };
-        Nep171Controller::mint(self, &action)
-            .unwrap_or_else(|e| env::panic_str(&format!("Minting failed: {e}")));
+        Nep171Controller::mint(
+            self,
+            &Nep171Mint::new(vec![token_id.clone()], env::predecessor_account_id()),
+        )
+        .unwrap_or_else(|e| env::panic_str(&format!("Minting failed: {e}")));
 
         token_id
     }

--- a/tests/macros/standard/nep171/non_fungible_token.rs
+++ b/tests/macros/standard/nep171/non_fungible_token.rs
@@ -36,8 +36,8 @@ impl Contract {
         let token_id = format!("token_{}", self.next_token_id);
         self.next_token_id += 1;
         self.mint_with_metadata(
-            token_id.clone(),
-            env::predecessor_account_id(),
+            &token_id,
+            &env::predecessor_account_id(),
             &TokenMetadata::new()
                 .title(format!("Token {token_id}"))
                 .description(format!("This is token {token_id}.")),

--- a/tests/macros/standard/nep171/non_fungible_token.rs
+++ b/tests/macros/standard/nep171/non_fungible_token.rs
@@ -19,7 +19,7 @@ impl Contract {
     pub fn new() -> Self {
         let mut contract = Self { next_token_id: 0 };
 
-        contract.set_contract_metadata(ContractMetadata::new(
+        contract.set_contract_metadata(&ContractMetadata::new(
             "My NFT".to_string(),
             "MYNFT".to_string(),
             None,
@@ -38,7 +38,7 @@ impl Contract {
         self.mint_with_metadata(
             token_id.clone(),
             env::predecessor_account_id(),
-            TokenMetadata::new()
+            &TokenMetadata::new()
                 .title(format!("Token {token_id}"))
                 .description(format!("This is token {token_id}.")),
         )

--- a/workspaces-tests/src/bin/fungible_token.rs
+++ b/workspaces-tests/src/bin/fungible_token.rs
@@ -35,11 +35,7 @@ impl Contract {
     pub fn mint(&mut self, amount: U128) {
         Nep141Controller::mint(
             self,
-            &Nep141Mint {
-                amount: amount.into(),
-                receiver_id: env::predecessor_account_id().into(),
-                memo: None,
-            },
+            &Nep141Mint::new(amount.0, env::predecessor_account_id()),
         )
         .unwrap();
     }

--- a/workspaces-tests/src/bin/fungible_token.rs
+++ b/workspaces-tests/src/bin/fungible_token.rs
@@ -37,7 +37,7 @@ impl Contract {
             self,
             &Nep141Mint {
                 amount: amount.into(),
-                receiver_id: &env::predecessor_account_id(),
+                receiver_id: env::predecessor_account_id().into(),
                 memo: None,
             },
         )

--- a/workspaces-tests/src/bin/fungible_token.rs
+++ b/workspaces-tests/src/bin/fungible_token.rs
@@ -23,7 +23,7 @@ impl Contract {
             blobs: Vector::new(b"b"),
         };
 
-        contract.set_metadata(&FungibleTokenMetadata::new(
+        contract.set_metadata(&ContractMetadata::new(
             "My Fungible Token".into(),
             "MYFT".into(),
             24,

--- a/workspaces-tests/src/bin/non_fungible_token_full.rs
+++ b/workspaces-tests/src/bin/non_fungible_token_full.rs
@@ -121,10 +121,10 @@ impl Contract {
         let receiver = env::predecessor_account_id();
         for token_id in token_ids {
             self.mint_with_metadata(
-                token_id.clone(),
-                receiver.clone(),
+                &token_id,
+                &receiver,
                 &TokenMetadata::new()
-                    .title(token_id)
+                    .title(token_id.clone())
                     .description("description"),
             )
             .unwrap_or_else(|e| env::panic_str(&format!("Failed to mint: {:#?}", e)));

--- a/workspaces-tests/src/bin/non_fungible_token_full.rs
+++ b/workspaces-tests/src/bin/non_fungible_token_full.rs
@@ -108,7 +108,7 @@ impl Contract {
     pub fn new() -> Self {
         let mut contract = Self {};
 
-        contract.set_contract_metadata(ContractMetadata::new(
+        contract.set_contract_metadata(&ContractMetadata::new(
             "My NFT Smart Contract".to_string(),
             "MNSC".to_string(),
             None,
@@ -123,7 +123,7 @@ impl Contract {
             self.mint_with_metadata(
                 token_id.clone(),
                 receiver.clone(),
-                TokenMetadata::new()
+                &TokenMetadata::new()
                     .title(token_id)
                     .description("description"),
             )

--- a/workspaces-tests/src/bin/non_fungible_token_nep171.rs
+++ b/workspaces-tests/src/bin/non_fungible_token_nep171.rs
@@ -30,8 +30,8 @@ impl Contract {
 
     pub fn mint(&mut self, token_ids: Vec<TokenId>) {
         let action = action::Nep171Mint {
-            token_ids: &token_ids,
-            receiver_id: &env::predecessor_account_id(),
+            token_ids,
+            receiver_id: env::predecessor_account_id().into(),
             memo: None,
         };
         Nep171Controller::mint(self, &action)

--- a/workspaces-tests/src/bin/non_fungible_token_nep171.rs
+++ b/workspaces-tests/src/bin/non_fungible_token_nep171.rs
@@ -1,7 +1,7 @@
 workspaces_tests::predicate!();
 
 use near_sdk::{env, log, near, PanicOnDefault};
-use near_sdk_contract_tools::{hook::Hook, standard::nep171::*, Nep171};
+use near_sdk_contract_tools::{hook::Hook, nft::Nep171Mint, standard::nep171::*, Nep171};
 
 #[derive(Nep171, PanicOnDefault)]
 #[nep171(transfer_hook = "Self")]
@@ -29,12 +29,10 @@ impl Contract {
     }
 
     pub fn mint(&mut self, token_ids: Vec<TokenId>) {
-        let action = action::Nep171Mint {
-            token_ids,
-            receiver_id: env::predecessor_account_id().into(),
-            memo: None,
-        };
-        Nep171Controller::mint(self, &action)
-            .unwrap_or_else(|e| env::panic_str(&format!("Failed to mint: {:#?}", e)));
+        Nep171Controller::mint(
+            self,
+            &Nep171Mint::new(token_ids, env::predecessor_account_id()),
+        )
+        .unwrap_or_else(|e| env::panic_str(&format!("Failed to mint: {:#?}", e)));
     }
 }

--- a/workspaces-tests/tests/fungible_token.rs
+++ b/workspaces-tests/tests/fungible_token.rs
@@ -295,7 +295,7 @@ async fn fail_run_out_of_space() {
         format!(
             "Smart contract panicked: Storage lock error: {}",
             InsufficientBalanceError {
-                account_id: alice.id().as_str().parse().unwrap(),
+                account_id: alice.id().clone(),
                 available: balance.available,
                 attempted_to_use: NearToken::from_yoctonear(100490000000000000000000),
             }
@@ -338,8 +338,8 @@ async fn transfer_call_normal() {
         result.logs().to_vec(),
         vec![
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 amount: U128(10),
                 memo: None,
             }])
@@ -388,16 +388,16 @@ async fn transfer_call_return() {
         result.logs().to_vec(),
         vec![
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 amount: U128(10),
                 memo: None,
             }])
             .to_event_string(),
             format!("Received 10 from {}", alice.id()),
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: bob.id().as_str().parse().unwrap(),
-                new_owner_id: alice.id().as_str().parse().unwrap(),
+                old_owner_id: bob.id().into(),
+                new_owner_id: alice.id().into(),
                 amount: U128(10),
                 memo: None,
             }])
@@ -445,8 +445,8 @@ async fn transfer_call_inner_transfer() {
         result.logs().to_vec(),
         vec![
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 amount: U128(10),
                 memo: None,
             }])
@@ -454,15 +454,15 @@ async fn transfer_call_inner_transfer() {
             format!("Received 10 from {}", alice.id()),
             format!("Transferring 10 to {}", charlie.id()),
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: bob.id().as_str().parse().unwrap(),
-                new_owner_id: charlie.id().as_str().parse().unwrap(),
+                old_owner_id: bob.id().into(),
+                new_owner_id: charlie.id().into(),
                 amount: U128(10),
                 memo: None,
             }])
             .to_event_string(),
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: bob.id().as_str().parse().unwrap(),
-                new_owner_id: alice.id().as_str().parse().unwrap(),
+                old_owner_id: bob.id().into(),
+                new_owner_id: alice.id().into(),
                 amount: U128(10),
                 memo: None,
             }])
@@ -514,16 +514,16 @@ async fn transfer_call_inner_panic() {
         result.logs().to_vec(),
         vec![
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 amount: U128(10),
                 memo: None,
             }])
             .to_event_string(),
             format!("Received 10 from {}", alice.id()),
             Nep141Event::FtTransfer(vec![FtTransferData {
-                old_owner_id: bob.id().as_str().parse().unwrap(),
-                new_owner_id: alice.id().as_str().parse().unwrap(),
+                old_owner_id: bob.id().into(),
+                new_owner_id: alice.id().into(),
                 amount: U128(10),
                 memo: None,
             }])

--- a/workspaces-tests/tests/native_multisig.rs
+++ b/workspaces-tests/tests/native_multisig.rs
@@ -181,7 +181,7 @@ async fn delete_account() {
             "receiver_id": contract.id(),
             "actions": [
                 PromiseAction::DeleteAccount {
-                    beneficiary_id: alice.id().as_str().parse().unwrap()
+                    beneficiary_id: alice.id().clone(),
                 },
             ],
         }))
@@ -393,7 +393,7 @@ async fn add_both_access_key_kinds_and_delete() {
         execute_actions(vec![PromiseAction::AddAccessKey {
             public_key: new_public_key_string.clone(),
             allowance: NearToken::from_yoctonear(1234567890),
-            receiver_id: alice.id().as_str().parse().unwrap(),
+            receiver_id: alice.id().clone(),
             function_names: vec!["one".into(), "two".into(), "three".into()],
             nonce: None,
         }])

--- a/workspaces-tests/tests/non_fungible_token.rs
+++ b/workspaces-tests/tests/non_fungible_token.rs
@@ -31,22 +31,9 @@ const RECEIVER_WASM: &[u8] =
 
 const THIRTY_TERAGAS: Gas = Gas::from_gas(30_000_000_000_000);
 
-fn token_meta(id: String) -> near_sdk::serde_json::Value {
-    near_sdk::serde_json::to_value(TokenMetadata {
-        title: Some(id),
-        description: Some("description".to_string()),
-        media: None,
-        media_hash: None,
-        copies: None,
-        issued_at: None,
-        expires_at: None,
-        starts_at: None,
-        updated_at: None,
-        extra: None,
-        reference: None,
-        reference_hash: None,
-    })
-    .unwrap()
+fn token_meta(id: impl Into<String>) -> near_sdk::serde_json::Value {
+    near_sdk::serde_json::to_value(TokenMetadata::new().title(id).description("description"))
+        .unwrap()
 }
 
 async fn setup_balances(
@@ -165,7 +152,7 @@ async fn create_and_mint_with_metadata_and_enumeration() {
             token_id: "token_0".to_string(),
             owner_id: alice.id().clone(),
             extensions_metadata: [
-                ("metadata".to_string(), token_meta("token_0".to_string())),
+                ("metadata".to_string(), token_meta("token_0")),
                 ("approved_account_ids".to_string(), json!({})),
                 ("funky_data".to_string(), json!({"funky": "data"})),
             ]
@@ -178,7 +165,7 @@ async fn create_and_mint_with_metadata_and_enumeration() {
             token_id: "token_1".to_string(),
             owner_id: bob.id().clone(),
             extensions_metadata: [
-                ("metadata".to_string(), token_meta("token_1".to_string())),
+                ("metadata".to_string(), token_meta("token_1")),
                 ("approved_account_ids".to_string(), json!({})),
                 ("funky_data".to_string(), json!({"funky": "data"})),
             ]
@@ -191,7 +178,7 @@ async fn create_and_mint_with_metadata_and_enumeration() {
             token_id: "token_2".to_string(),
             owner_id: charlie.id().clone(),
             extensions_metadata: [
-                ("metadata".to_string(), token_meta("token_2".to_string())),
+                ("metadata".to_string(), token_meta("token_2")),
                 ("approved_account_ids".to_string(), json!({})),
                 ("funky_data".to_string(), json!({"funky": "data"})),
             ]
@@ -805,7 +792,7 @@ async fn transfer_approval_success() {
         token_id: "token_0".into(),
         owner_id: alice.id().clone(),
         extensions_metadata: [
-            ("metadata".to_string(), token_meta("token_0".to_string())),
+            ("metadata".to_string(), token_meta("token_0")),
             (
                 "approved_account_ids".to_string(),
                 json!({
@@ -850,7 +837,7 @@ async fn transfer_approval_success() {
             token_id: "token_0".to_string(),
             owner_id: charlie.id().clone(),
             extensions_metadata: [
-                ("metadata".to_string(), token_meta("token_0".to_string())),
+                ("metadata".to_string(), token_meta("token_0")),
                 ("approved_account_ids".to_string(), json!({})),
                 ("funky_data".to_string(), json!({"funky": "data"})),
             ]

--- a/workspaces-tests/tests/non_fungible_token.rs
+++ b/workspaces-tests/tests/non_fungible_token.rs
@@ -99,7 +99,7 @@ async fn create_and_mint() {
         token_0,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: alice.id().as_str().parse().unwrap(),
+            owner_id: alice.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -107,7 +107,7 @@ async fn create_and_mint() {
         token_1,
         Some(Token {
             token_id: "token_1".to_string(),
-            owner_id: bob.id().as_str().parse().unwrap(),
+            owner_id: bob.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -115,7 +115,7 @@ async fn create_and_mint() {
         token_2,
         Some(Token {
             token_id: "token_2".to_string(),
-            owner_id: charlie.id().as_str().parse().unwrap(),
+            owner_id: charlie.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -163,7 +163,7 @@ async fn create_and_mint_with_metadata_and_enumeration() {
         token_0,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: alice.id().as_str().parse().unwrap(),
+            owner_id: alice.id().clone(),
             extensions_metadata: [
                 ("metadata".to_string(), token_meta("token_0".to_string())),
                 ("approved_account_ids".to_string(), json!({})),
@@ -176,7 +176,7 @@ async fn create_and_mint_with_metadata_and_enumeration() {
         token_1,
         Some(Token {
             token_id: "token_1".to_string(),
-            owner_id: bob.id().as_str().parse().unwrap(),
+            owner_id: bob.id().clone(),
             extensions_metadata: [
                 ("metadata".to_string(), token_meta("token_1".to_string())),
                 ("approved_account_ids".to_string(), json!({})),
@@ -189,7 +189,7 @@ async fn create_and_mint_with_metadata_and_enumeration() {
         token_2,
         Some(Token {
             token_id: "token_2".to_string(),
-            owner_id: charlie.id().as_str().parse().unwrap(),
+            owner_id: charlie.id().clone(),
             extensions_metadata: [
                 ("metadata".to_string(), token_meta("token_2".to_string())),
                 ("approved_account_ids".to_string(), json!({})),
@@ -337,11 +337,11 @@ async fn transfer_success() {
         vec![
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 authorized_id: None,
                 memo: None,
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
             }])
             .to_event_string(),
             "after_nft_transfer(token_0)".to_string(),
@@ -358,7 +358,7 @@ async fn transfer_success() {
         token_0,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: bob.id().as_str().parse().unwrap(),
+            owner_id: bob.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -366,7 +366,7 @@ async fn transfer_success() {
         token_1,
         Some(Token {
             token_id: "token_1".to_string(),
-            owner_id: bob.id().as_str().parse().unwrap(),
+            owner_id: bob.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -374,7 +374,7 @@ async fn transfer_success() {
         token_2,
         Some(Token {
             token_id: "token_2".to_string(),
-            owner_id: charlie.id().as_str().parse().unwrap(),
+            owner_id: charlie.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -543,10 +543,10 @@ async fn transfer_call_success() {
         vec![
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
                 authorized_id: None,
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 memo: None,
             }])
             .to_event_string(),
@@ -561,7 +561,7 @@ async fn transfer_call_success() {
         nft_token(&contract, "token_0").await,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: bob.id().as_str().parse().unwrap(),
+            owner_id: bob.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -602,10 +602,10 @@ async fn transfer_call_return_success() {
         vec![
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
                 authorized_id: None,
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 memo: None,
             }])
             .to_event_string(),
@@ -613,10 +613,10 @@ async fn transfer_call_return_success() {
             format!("Received token_0 from {} via {}", alice.id(), alice.id()),
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
                 authorized_id: None,
-                old_owner_id: bob.id().as_str().parse().unwrap(),
-                new_owner_id: alice.id().as_str().parse().unwrap(),
+                old_owner_id: bob.id().into(),
+                new_owner_id: alice.id().into(),
                 memo: None,
             }])
             .to_event_string(),
@@ -630,7 +630,7 @@ async fn transfer_call_return_success() {
         nft_token(&contract, "token_0").await,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: alice.id().as_str().parse().unwrap(),
+            owner_id: alice.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -671,10 +671,10 @@ async fn transfer_call_receiver_panic() {
         vec![
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
                 authorized_id: None,
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 memo: None,
             }])
             .to_event_string(),
@@ -682,10 +682,10 @@ async fn transfer_call_receiver_panic() {
             format!("Received token_0 from {} via {}", alice.id(), alice.id()),
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
                 authorized_id: None,
-                old_owner_id: bob.id().as_str().parse().unwrap(),
-                new_owner_id: alice.id().as_str().parse().unwrap(),
+                old_owner_id: bob.id().into(),
+                new_owner_id: alice.id().into(),
                 memo: None,
             }])
             .to_event_string(),
@@ -699,7 +699,7 @@ async fn transfer_call_receiver_panic() {
         nft_token(&contract, "token_0").await,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: alice.id().as_str().parse().unwrap(),
+            owner_id: alice.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -743,10 +743,10 @@ async fn transfer_call_receiver_send_return() {
         vec![
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
                 authorized_id: None,
-                old_owner_id: alice.id().as_str().parse().unwrap(),
-                new_owner_id: bob.id().as_str().parse().unwrap(),
+                old_owner_id: alice.id().into(),
+                new_owner_id: bob.id().into(),
                 memo: None,
             }])
             .to_event_string(),
@@ -755,10 +755,10 @@ async fn transfer_call_receiver_send_return() {
             format!("Transferring token_0 to {}", charlie.id()),
             "before_nft_transfer(token_0)".to_string(),
             Nep171Event::NftTransfer(vec![NftTransferLog {
-                token_ids: vec!["token_0".to_string()],
+                token_ids: vec!["token_0".into()],
                 authorized_id: None,
-                old_owner_id: bob.id().as_str().parse().unwrap(),
-                new_owner_id: charlie.id().as_str().parse().unwrap(),
+                old_owner_id: bob.id().into(),
+                new_owner_id: charlie.id().into(),
                 memo: None,
             }])
             .to_event_string(),
@@ -773,7 +773,7 @@ async fn transfer_call_receiver_send_return() {
         nft_token(&contract, "token_0").await,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: charlie.id().as_str().parse().unwrap(),
+            owner_id: charlie.id().clone(),
             extensions_metadata: Default::default(),
         }),
     );
@@ -803,7 +803,7 @@ async fn transfer_approval_success() {
 
     let expected_view_token = Token {
         token_id: "token_0".into(),
-        owner_id: alice.id().as_str().parse().unwrap(),
+        owner_id: alice.id().clone(),
         extensions_metadata: [
             ("metadata".to_string(), token_meta("token_0".to_string())),
             (
@@ -848,7 +848,7 @@ async fn transfer_approval_success() {
         nft_token(&contract, "token_0").await,
         Some(Token {
             token_id: "token_0".to_string(),
-            owner_id: charlie.id().as_str().parse().unwrap(),
+            owner_id: charlie.id().clone(),
             extensions_metadata: [
                 ("metadata".to_string(), token_meta("token_0".to_string())),
                 ("approved_account_ids".to_string(), json!({})),
@@ -908,8 +908,8 @@ async fn transfer_approval_unapproved_fail() {
     let expected_error_message = format!(
         "Smart contract panicked: {}",
         nep171::error::SenderNotApprovedError {
-            owner_id: alice.id().as_str().parse().unwrap(),
-            sender_id: bob.id().as_str().parse().unwrap(),
+            owner_id: alice.id().clone(),
+            sender_id: bob.id().clone(),
             token_id: "token_0".to_string(),
             approval_id: 0,
         }
@@ -971,7 +971,7 @@ async fn transfer_approval_double_approval_fail() {
     let expected_error = format!(
         "Smart contract panicked: {}",
         Nep178ApproveError::AccountAlreadyApproved(AccountAlreadyApprovedError {
-            account_id: bob.id().as_str().parse().unwrap(),
+            account_id: bob.id().clone(),
             token_id: "token_0".to_string(),
         }),
     );
@@ -1000,7 +1000,7 @@ async fn transfer_approval_unauthorized_approval_fail() {
     let expected_error = format!(
         "Smart contract panicked: {}",
         Nep178ApproveError::Unauthorized(UnauthorizedError {
-            account_id: bob.id().as_str().parse().unwrap(),
+            account_id: bob.id().clone(),
             token_id: "token_0".to_string(),
         }),
     );
@@ -1094,8 +1094,8 @@ async fn transfer_approval_approved_but_wrong_approval_id_fail() {
         "Smart contract panicked: {}",
         nep171::error::Nep171TransferError::SenderNotApproved(
             nep171::error::SenderNotApprovedError {
-                sender_id: bob.id().as_str().parse().unwrap(),
-                owner_id: alice.id().as_str().parse().unwrap(),
+                sender_id: bob.id().clone(),
+                owner_id: alice.id().clone(),
                 token_id: "token_0".to_string(),
                 approval_id: 1,
             }


### PR DESCRIPTION
- Take ownership less (use more references)
- Renaming for consistency
- Use `AccountIdRef` and `Cow<AccountIdRef>` in more places
- Adds convenience constructor functions for action structs to elide complexity/ugliness w.r.t. `Cow<AccountIdRef>`