### PR TITLE
fix: derive `NearSchema` for NEP-171 Token struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ version = "3.0.0"
 # normal dependencies
 near-sdk = { version = "5.1.0", default-features = false }
 near-sdk-contract-tools-macros = { version = "=3.0.0", path = "./macros" }
-schemars = "0.8.19"
 thiserror = "1"
 
 # macro dependencies
@@ -54,7 +53,6 @@ missing-docs = "warn"
 [dependencies]
 near-sdk = { workspace = true, default-features = false, features = ["legacy"] }
 near-sdk-contract-tools-macros.workspace = true
-schemars.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ version = "3.0.0"
 # normal dependencies
 near-sdk = { version = "5.1.0", default-features = false }
 near-sdk-contract-tools-macros = { version = "=3.0.0", path = "./macros" }
+schemars = "0.8.19"
 thiserror = "1"
 
 # macro dependencies
@@ -53,6 +54,7 @@ missing-docs = "warn"
 [dependencies]
 near-sdk = { workspace = true, default-features = false, features = ["legacy"] }
 near-sdk-contract-tools-macros.workspace = true
+schemars.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/src/standard/nep171/mod.rs
+++ b/src/standard/nep171/mod.rs
@@ -43,7 +43,7 @@ use near_sdk::{
     borsh::BorshSerialize,
     near,
     serde::{Deserialize, Serialize},
-    AccountId, AccountIdRef, BorshStorageKey, Gas,
+    AccountId, AccountIdRef, BorshStorageKey, Gas, NearSchema,
 };
 
 use crate::{hook::Hook, slot::Slot, standard::nep297::Event, DefaultStorageKey};
@@ -415,7 +415,7 @@ impl<T: Nep171ControllerInternal> Nep171Controller for T {
 }
 
 /// Token information structure.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, NearSchema)]
 #[serde(crate = "near_sdk::serde")]
 pub struct Token {
     /// Token ID.


### PR DESCRIPTION
This allows the NFT components to work more easily with the ABI generation with [`cargo-near`](https://github.com/near/cargo-near).