### PR TITLE
feat/fix: convenience methods use `impl Into<T>` more **slightly breaking**

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ impl MyNftContract {
     pub fn new() -> Self {
         let mut contract = Self {};
 
-        contract.set_contract_metadata(&ContractMetadata::new(
-            "My NFT".to_string(),
-            "MNFT".to_string(),
-            None,
-        ));
+        contract.set_contract_metadata(&ContractMetadata::new("My NFT", "MNFT", None));
 
         contract
     }
@@ -43,11 +39,7 @@ impl MyFtContract {
     pub fn new() -> Self {
         let mut contract = Self {};
 
-        contract.set_metadata(&ContractMetadata::new(
-            "My Fungible Token".into(),
-            "MYFT".into(),
-            24,
-        ));
+        contract.set_metadata(&ContractMetadata::new("My Fungible Token", "MYFT", 24));
 
         contract
     }
@@ -168,11 +160,7 @@ impl MyFt {
     pub fn new() -> Self {
         let mut contract = Self {};
 
-        contract.set_metadata(&ContractMetadata::new(
-            "My Fungible Token".to_string(),
-            "MYFT".to_string(),
-            24,
-        ));
+        contract.set_metadata(&ContractMetadata::new("My Fungible Token", "MYFT", 24));
 
         contract
     }

--- a/src/standard/nep148.rs
+++ b/src/standard/nep148.rs
@@ -38,11 +38,11 @@ pub struct ContractMetadata {
 impl ContractMetadata {
     /// Creates a new metadata struct.
     #[must_use]
-    pub fn new(name: String, symbol: String, decimals: u8) -> Self {
+    pub fn new(name: impl Into<String>, symbol: impl Into<String>, decimals: u8) -> Self {
         Self {
             spec: FT_METADATA_SPEC.into(),
-            name,
-            symbol,
+            name: name.into(),
+            symbol: symbol.into(),
             icon: None,
             reference: None,
             reference_hash: None,
@@ -52,43 +52,43 @@ impl ContractMetadata {
 
     /// Sets the spec field.
     #[must_use]
-    pub fn spec(mut self, spec: String) -> Self {
-        self.spec = spec;
+    pub fn spec(mut self, spec: impl Into<String>) -> Self {
+        self.spec = spec.into();
         self
     }
 
     /// Sets the name field.
     #[must_use]
-    pub fn name(mut self, name: String) -> Self {
-        self.name = name;
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
         self
     }
 
     /// Sets the symbol field.
     #[must_use]
-    pub fn symbol(mut self, symbol: String) -> Self {
-        self.symbol = symbol;
+    pub fn symbol(mut self, symbol: impl Into<String>) -> Self {
+        self.symbol = symbol.into();
         self
     }
 
     /// Sets the icon field.
     #[must_use]
-    pub fn icon(mut self, icon: String) -> Self {
-        self.icon = Some(icon);
+    pub fn icon(mut self, icon: impl Into<String>) -> Self {
+        self.icon = Some(icon.into());
         self
     }
 
     /// Sets the reference field.
     #[must_use]
-    pub fn reference(mut self, reference: String) -> Self {
-        self.reference = Some(reference);
+    pub fn reference(mut self, reference: impl Into<String>) -> Self {
+        self.reference = Some(reference.into());
         self
     }
 
     /// Sets the `reference_hash` field.
     #[must_use]
-    pub fn reference_hash(mut self, reference_hash: Base64VecU8) -> Self {
-        self.reference_hash = Some(reference_hash);
+    pub fn reference_hash(mut self, reference_hash: impl Into<Base64VecU8>) -> Self {
+        self.reference_hash = Some(reference_hash.into());
         self
     }
 

--- a/src/standard/nep177.rs
+++ b/src/standard/nep177.rs
@@ -53,11 +53,11 @@ impl ContractMetadata {
     /// Creates a new contract metadata, specifying the name, symbol, and
     /// optional base URI. Other fields are set to `None`.
     #[must_use]
-    pub fn new(name: String, symbol: String, base_uri: Option<String>) -> Self {
+    pub fn new(name: impl Into<String>, symbol: impl Into<String>, base_uri: Option<String>) -> Self {
         Self {
             spec: Self::SPEC.to_string(),
-            name,
-            symbol,
+            name: name.into(),
+            symbol: symbol.into(),
             icon: None,
             base_uri,
             reference: None,

--- a/src/standard/nep177.rs
+++ b/src/standard/nep177.rs
@@ -53,7 +53,11 @@ impl ContractMetadata {
     /// Creates a new contract metadata, specifying the name, symbol, and
     /// optional base URI. Other fields are set to `None`.
     #[must_use]
-    pub fn new(name: impl Into<String>, symbol: impl Into<String>, base_uri: Option<String>) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        symbol: impl Into<String>,
+        base_uri: Option<String>,
+    ) -> Self {
         Self {
             spec: Self::SPEC.to_string(),
             name: name.into(),

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -413,11 +413,7 @@ mod pausable_fungible_token {
         pub fn new() -> Self {
             let mut contract = Self { storage_usage: 0 };
 
-            contract.set_metadata(&ContractMetadata::new(
-                "Pausable Fungible Token".into(),
-                "PFT".into(),
-                18,
-            ));
+            contract.set_metadata(&ContractMetadata::new("Pausable Fungible Token", "PFT", 18));
 
             contract
         }

--- a/tests/macros/standard/fungible_token.rs
+++ b/tests/macros/standard/fungible_token.rs
@@ -12,9 +12,9 @@ impl MyFungibleTokenContract {
         let mut contract = Self {};
 
         contract.set_metadata(
-            &ContractMetadata::new("My Fungible Token".into(), "MYFT".into(), 24)
-                .icon("https://example.com/icon.png".into())
-                .reference("https://example.com/metadata.json".into())
+            &ContractMetadata::new("My Fungible Token", "MYFT", 24)
+                .icon("https://example.com/icon.png")
+                .reference("https://example.com/metadata.json")
                 .reference_hash(Base64VecU8::from([97, 115, 100, 102].to_vec())),
         );
 

--- a/tests/macros/standard/nep148.rs
+++ b/tests/macros/standard/nep148.rs
@@ -12,10 +12,10 @@ impl DerivesFTMetadata {
         let mut contract = Self {};
 
         contract.set_metadata(
-            &ContractMetadata::new("Test Fungible Token".into(), "TFT".into(), 18)
-                .icon("https://example.com/icon.png".into())
-                .reference("https://example.com/metadata.json".into())
-                .reference_hash(Base64VecU8::from([97, 115, 100, 102].to_vec())),
+            &ContractMetadata::new("Test Fungible Token", "TFT", 18)
+                .icon("https://example.com/icon.png")
+                .reference("https://example.com/metadata.json")
+                .reference_hash(vec![97, 115, 100, 102]),
         );
 
         contract

--- a/workspaces-tests/src/bin/fungible_token.rs
+++ b/workspaces-tests/src/bin/fungible_token.rs
@@ -23,11 +23,7 @@ impl Contract {
             blobs: Vector::new(b"b"),
         };
 
-        contract.set_metadata(&ContractMetadata::new(
-            "My Fungible Token".into(),
-            "MYFT".into(),
-            24,
-        ));
+        contract.set_metadata(&ContractMetadata::new("My Fungible Token", "MYFT", 24));
 
         contract
     }


### PR DESCRIPTION
This is a slightly breaking change, simply because parameters of the form `_.into()` passed into these functions will now fail automatic type resolution in most cases. No functionally breaking changes though, so will not be incrementing major revision.